### PR TITLE
Attempt to look up serviceaccount token

### DIFF
--- a/lib/logstash/filters/kubernetes_metadata.rb
+++ b/lib/logstash/filters/kubernetes_metadata.rb
@@ -304,6 +304,15 @@ class LogStash::Filters::KubernetesMetadata < LogStash::Filters::Base
         bearer_key = @auth_bearer_key
 
         rest_opts.merge!( headers: {Authorization: "Bearer #{bearer_key}"} )
+      else
+        @logger.debug("Attempting to look up default service account token")
+        begin
+          bearer_key = File.read('/var/run/secrets/kubernetes.io/serviceaccount/token')
+
+          rest_opts.merge!( headers: {Authorization: "Bearer #{bearer_key}"} )
+        rescue => e
+          @logger.debug("Error reading default service account token: #{e}")
+        end
       end
 
       @logger.debug("rest_opts: #{rest_opts}")


### PR DESCRIPTION
If no auth configuration is provided, attempt to look up the default
serviceaccount token. This token will be present if logstash is running
in a Pod in Kubernetes, has a serviceaccount, and the Pod and/or
serviceaccount are set to automount the token.

This patch is similar to one that I'm running in our Kubernetes clusters right now, except that we seem to be running an older version of the plugin, so the code looks slightly different on my side.

This is the first time I've ever written Ruby, so I took the shortest path to the goal. Possible improvements, if reviewers don't mind helping me get there:
* Currently the plugin will try to read the token file every time, rather than reading it once and caching the token. Should it try to read the token once and cache it on init? Is there an appropriate reload hook for it to retry looking up the token that I could hook into?
* Currently the plugin always looks up the token if no other auth options are specified, which is a change in behavior. Previously, if no other auth was configured, the plugin would proceed without auth. I could instead add a new configuration option for using the service account, if that seems appropriate. I'm open to suggestions.