### PR TITLE
Add kuberneters service token reader

### DIFF
--- a/logstash-filter-kubernetes_metadata.gemspec
+++ b/logstash-filter-kubernetes_metadata.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-filter-kubernetes_metadata'
-  s.version         = '1.0.5'
-  s.licenses      = ['Apache License (2.0)']
+  s.version         = '1.1.0'
+  s.licenses      = ['Apache-2.0']
   s.summary       = 'Parses kubernetes host and pod metadata from log filename'
   s.homepage      = 'https://github.com/phutchins/logstash-filter-kubernetes_metadata'
   s.authors       = ['Philip Hutchins']


### PR DESCRIPTION
Add kuberneters service token reader.

This way if someone runs the plugin inside a kubernetes container (as a sidecar or daemonset) it can automatically pick up the service token for auth.

Also updated gemspec file for new version and new license string which seems to make the gem builder happy.  Still apache-2.0, just with a different string that seems to cause less warnings.
